### PR TITLE
Fix GitHub link to repository name

### DIFF
--- a/products/sharecar.md
+++ b/products/sharecar.md
@@ -6,7 +6,7 @@ technologies: Ruby
 
 ## What?
 
-- [github](https://github.com/genya0407/sharecar-rails)
+- [genya0407/sharecar-rails](https://github.com/genya0407/sharecar-rails)
 - [sandbox app](https://enigmatic-refuge-39913.herokuapp.com/)
   - Email: example@example.com
   - Password: password


### PR DESCRIPTION
Other product articles use the repository name as a link to GitHub.

The bottom fix is probably GitHub added a line break.
Because I fixed it from GitHub's web editor.